### PR TITLE
Fix bubble size division by zero

### DIFF
--- a/pages/mods/funcs.py
+++ b/pages/mods/funcs.py
@@ -106,7 +106,11 @@ def fiskeslag(df, arter, cords):
 
     min_bubble = locs['Produktvekt'].min()
     max_bubble = locs['Produktvekt'].max()
-    locs['BubbleSize'] = ((locs['Produktvekt'] - min_bubble) / (max_bubble - min_bubble)) * (10 - 1) + 1
+    if max_bubble == min_bubble:
+        # Avoid division by zero if only a single location is present
+        locs['BubbleSize'] = 5
+    else:
+        locs['BubbleSize'] = ((locs['Produktvekt'] - min_bubble) / (max_bubble - min_bubble)) * (10 - 1) + 1
     # df['Color'] = df['Landingsdato'].apply(lambda x: date_difference_color(pd.Timestamp("2023-08-10"), x))
     # locs['Color'] = locs['Landingsdato'].apply(lambda x: bubblecolor(latest_date, x))
  


### PR DESCRIPTION
## Summary
- handle case with only a single location when calculating bubble sizes

## Testing
- `python -m py_compile pages/mods/funcs.py`
- `python -m py_compile The_Others.py`


------
https://chatgpt.com/codex/tasks/task_e_683feb6cfb9c832b86ce8188c4528e97