### PR TITLE
Remove datetime from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,7 @@ pandas==1.5.2
 streamlit_option_menu
 leafmap
 Pillow
-plotly.express
+plotly
 folium
 streamlit_folium
 geopandas
-datetime


### PR DESCRIPTION
## Summary
- replace `plotly.express` with `plotly` in requirements
- remove the obsolete `datetime` dependency

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_683fee498138832bac860c8046895022