### PR TITLE
Implement historical landing fetch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ plotly
 folium
 streamlit_folium
 geopandas
+requests
 datetime
 pytest
 main

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -27,7 +27,14 @@ sys.modules['plotly.express'] = plotly_module.express
 sys.modules['plotly.graph_objects'] = plotly_module.graph_objects
 
 sys.modules['last_seddel'] = types.ModuleType('last_seddel')
-sys.modules['pandas'] = types.ModuleType('pandas')
+pandas_module = types.ModuleType('pandas')
+pandas_module.DataFrame = object
+sys.modules['pandas'] = pandas_module
+
+# Provide a dummy requests module
+requests_module = types.ModuleType('requests')
+requests_module.get = lambda *args, **kwargs: None
+sys.modules['requests'] = requests_module
 
 # Provide minimal Pillow structure
 PIL_module = types.ModuleType('PIL')


### PR DESCRIPTION
## Summary
- add function to fetch landing data from fiskeridir.no and visualize it on the *Historisk* page
- include requests as dependency
- update tests to mock `requests` and `pandas` modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff08788f4832bab681b93409e55b6